### PR TITLE
sawyer 0.6 has few changes that probably won't break anything

### DIFF
--- a/bugsnag-api.gemspec
+++ b/bugsnag-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sawyer", '~> 0.5.3'
+  spec.add_dependency "sawyer", '>= 0.5.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
[Relevant changes](https://github.com/lostisland/sawyer/compare/v0.5.3...v0.6.0)

Seems to be fairly unsubstantial, probably safe to just allow upper versions until there's a conflict.