### PR TITLE
More rigorous pagination example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ Many Bugsnag API resources are paginated. While you may be tempted to start addi
 
 ```ruby
 errors = Bugsnag::Api.errors("project-id", per_page: 100)
-errors.concat Bugsnag::Api.last_response.rels[:next].get.data
+last_response = Bugsnag::Api.last_response
+until last_response.rels[:next].nil?
+  last_response = last_response.rels[:next].get
+  errors.concat last_response.data
+end
 ```
 
 


### PR DESCRIPTION
The way this example was written, I thought the `last_response` method was
updated with each `get` call such that I could get multiple pages as follows:

```
errors = Bugsnag::Api.errors("project-id", per_page: 100)
errors.concat Bugsnag::Api.last_response.rels[:next].get.data
errors.concat Bugsnag::Api.last_response.rels[:next].get.data
errors.concat Bugsnag::Api.last_response.rels[:next].get.data
...
```

This turns out to simply load the same page over and over.

Hopefully this new example makes it clear how to get pages 3 and up.