### PR TITLE
Added 429 error response to rate limit, and test

### DIFF
--- a/lib/bugsnag/api/error.rb
+++ b/lib/bugsnag/api/error.rb
@@ -23,6 +23,7 @@ module Bugsnag
                     when 409      then Bugsnag::Api::Conflict
                     when 415      then Bugsnag::Api::UnsupportedMediaType
                     when 422      then Bugsnag::Api::UnprocessableEntity
+                    when 429      then Bugsnag::Api::RateLimitExceeded
                     when 400..499 then Bugsnag::Api::ClientError
                     when 500      then Bugsnag::Api::InternalServerError
                     when 501      then Bugsnag::Api::NotImplemented
@@ -101,6 +102,9 @@ module Bugsnag
 
     # Raised when Bugsnag returns a 422 HTTP status code
     class UnprocessableEntity < ClientError; end
+
+    # Raised when the api limit has been exceeded
+    class RateLimitExceeded < ClientError; end
 
     # Raised on errors in the 500-599 range
     class ServerError < Error; end

--- a/spec/bugsnag/api/client_spec.rb
+++ b/spec/bugsnag/api/client_spec.rb
@@ -87,6 +87,11 @@ describe Bugsnag::Api::Client do
       expect { Bugsnag::Api.get('/booya') }.to raise_error(Bugsnag::Api::NotFound)
     end
 
+    it "raises on 429" do
+      stub_get('/test').to_return(:status => 429)
+      expect { Bugsnag::Api.get('/test') }.to raise_error(Bugsnag::Api::RateLimitExceeded)
+    end
+
     it "raises on 500" do
       stub_get('/boom').to_return(:status => 500)
       expect { Bugsnag::Api.get('/boom') }.to raise_error(Bugsnag::Api::InternalServerError)


### PR DESCRIPTION
Adds a readable error in the case the API rate limit is exceeded (status: 429)