### PR TITLE
Adding 'X-Bugsnag-Api' header so that on-prem clients may use this tool

### DIFF
--- a/lib/bugsnag/api/client.rb
+++ b/lib/bugsnag/api/client.rb
@@ -149,6 +149,7 @@ module Bugsnag
         @agent ||= Sawyer::Agent.new(configuration.endpoint, sawyer_options) do |http|
           http.headers[:content_type] = "application/json"
           http.headers[:'X-Version'] = "2"
+          http.headers[:'X-Bugsnag-Api'] = "true"
           http.headers[:user_agent] = configuration.user_agent
 
           if basic_authenticated?


### PR DESCRIPTION
All on-premise users need: http.headers[:'X-Bugsnag-Api'] = "true" to get a 200 response.  This header should not interfere with clients using the tool for the Bugsnag cloud API.
