### PR TITLE
fix(error args): Refactor error methods

### DIFF
--- a/lib/bugsnag/api/client/collaborators.rb
+++ b/lib/bugsnag/api/client/collaborators.rb
@@ -19,7 +19,7 @@ module Bugsnag
         # @argument project_id [String] ID of project to get collaborators from (conflicts with org_id)
         # @argument org_id [String] ID of organization to get collaborators from (conflicts with project_id)
         #
-        # @option per_page [Number] Amount of results per-page             
+        # @option per_page [Number] Amount of results per-page
         # @return [Array<Sawyer::Resource>] List of Collaborators
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/organizations/collaborators/list-collaborators
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/organizations/collaborators/list-collaborators-on-a-project
@@ -84,4 +84,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/currentuser.rb
+++ b/lib/bugsnag/api/client/currentuser.rb
@@ -30,4 +30,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/errors.rb
+++ b/lib/bugsnag/api/client/errors.rb
@@ -8,6 +8,8 @@ module Bugsnag
       module Errors
         # List the Errors on a Project
         #
+        # @argument id [String] optional ID of error to retrieve
+        #
         # @option base [String] Only Error Events occuring before this time will be returned
         # @option sort [String] Which field to sort by, one of: last_seen, first_seen, users, events, unsorted
         # @option direction [String] Which direction to sort the result by, one of: asc, desc
@@ -15,16 +17,14 @@ module Bugsnag
         # @return [Array<Sawyer::Resource>] List of Project Errors
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/errors/errors/list-the-errors-on-a-project
         def errors(project_id, id=nil, options = {})
-          paginate "projects/#{project_id}/errors", options
+          if id.nil?
+            paginate "projects/#{project_id}/errors", options
+          else
+            get "projects/#{project_id}/errors/#{id}", options
+          end
         end
 
-        # View an Error
-        #
-        # @return [Sawyer::Resource] Requested Error
-        # @see http://docs.bugsnagapiv2.apiary.io/#reference/errors/errors/view-an-error
-        def error(project_id, id, options = {})
-          get "projects/#{project_id}/errors/#{id}", options
-        end
+        alias error errors
 
         # Update an Error
         #
@@ -55,7 +55,7 @@ module Bugsnag
         # @argument error_id [String] ID of error to delete (conflicts with project_id)
         # @argument project_id [String] Id of project to delete all errors from (conflicts with error_id)
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/errors/errors/delete-an-error
         def delete_errors(project_id, error_id=nil, options = {})
           if !error_id.nil?
@@ -68,4 +68,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/eventfields.rb
+++ b/lib/bugsnag/api/client/eventfields.rb
@@ -38,7 +38,7 @@ module Bugsnag
 
         # Delete a custom Event Field
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/projects/event-fields/delete-a-custom-event-field
         def delete_event_field(project_id, display_id, options = {})
           boolean_from_resposne :delete, "project/#{project_id}/event_fields/#{display_id}", options
@@ -47,4 +47,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/events.rb
+++ b/lib/bugsnag/api/client/events.rb
@@ -16,7 +16,7 @@ module Bugsnag
 
         # Delete an Event
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/errors/events/delete-an-event
         def delete_event(project_id, id, options = {})
           boolean_from_response :delete, "projects/#{project_id}/events/#{id}", options
@@ -57,4 +57,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/organizations.rb
+++ b/lib/bugsnag/api/client/organizations.rb
@@ -34,7 +34,7 @@ module Bugsnag
 
         # Delete an Organization
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/organizations/organizations/delete-an-organization
         def delete_organization(id, options = {})
           boolean_from_response :delete, "organizations/#{id}", options
@@ -43,4 +43,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/pivots.rb
+++ b/lib/bugsnag/api/client/pivots.rb
@@ -26,7 +26,7 @@ module Bugsnag
         #
         # @option filters [Object] An optional filter object, see http://docs.bugsnagapiv2.apiary.io/#introduction/filtering
         # @option sort [String] Sorting method
-        # @option base [String] Only Events occuring before this time will be used 
+        # @option base [String] Only Events occuring before this time will be used
         # @return [Array<Sawyer::Resource>] List of values for the Pivots requested
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/errors/pivots/list-values-of-a-pivot-on-an-error
         def pivot_values(project_id, ef_display_id, error_id=nil, options = {})
@@ -40,4 +40,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/projects.rb
+++ b/lib/bugsnag/api/client/projects.rb
@@ -42,7 +42,7 @@ module Bugsnag
 
         # Regenerate a Project's notifier API key
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/projects/projects/regenerate-a-project's-notifier-api-key
         def regenerate_api_key(id, options = {})
           delete "projects/#{id}/api_key", options
@@ -50,7 +50,7 @@ module Bugsnag
 
         # Delete a Project
         #
-        # @return 
+        # @return
         # @see http://docs.bugsnagapiv2.apiary.io/#reference/organizations/organizations/delete-an-organization
         def delete_project(id, options = {})
           boolean_from_response :delete, "projects/#{id}", options
@@ -59,4 +59,3 @@ module Bugsnag
     end
   end
 end
-  

--- a/lib/bugsnag/api/client/trends.rb
+++ b/lib/bugsnag/api/client/trends.rb
@@ -39,4 +39,3 @@ module Bugsnag
     end
   end
 end
-  


### PR DESCRIPTION
Simplify the error/errors methods by combining them with an optional `id` parameter.

Alias `error` to `errors` to preserve original interface.

Fix remove trailing whitespace from several places.