### PR TITLE
remove plural from single organization call

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ documentation](http://www.rubydoc.info/gems/bugsnag-api/Bugsnag/Api/Client)
 orgs = Bugsnag::Api.organizations
 
 # Get a single organization
-org = Bugsnag::Api.organizations("organization-id")
+org = Bugsnag::Api.organization("organization-id")
 ```
 
 ### Collaborators


### PR DESCRIPTION
## Goal

Currently in the readme [organizations example](https://github.com/bugsnag/bugsnag-api-ruby#organizations) the call to retrieve a single organization is written as plural `Bugsnag::Api.organizations("organization-id")`. Should be `Bugsnag::Api.organization("organization-id")`.