### PR TITLE
Remove call to deprecated URI.escape.

### DIFF
--- a/lib/bugsnag/api/client.rb
+++ b/lib/bugsnag/api/client.rb
@@ -185,7 +185,7 @@ module Bugsnag
           end
         end
 
-        @last_response = response = agent.call(method, URI.escape(path.to_s), data, options)
+        @last_response = response = agent.call(method, path.to_s, data, options)
         response.data
       end
 


### PR DESCRIPTION
## Goal

In Ruby 3, `URI.escape` is removed. There is no simple replacement provided by Ruby.

## Design

As far as I can tell, this isn't necessary. When passing query parameters to GET requests, or form data to POST requests, we use the underlying Faraday bits with a Hash, which are encoded correctly. The `path` argument should already be a well-formed URI, or it will produce an HTTP error from the API as normal.

## Changeset

Simply removed the call to `URI.escape`.

## Testing

The RSpec test suite has 5 failing tests on master for me locally with Ruby 2.6.5. With Ruby 3.0.0, most of the suite fails with calls to `URI.escape`. After this call, I was back to the same 5 tests failing.