### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+## 2.0.3 (11 May 2021)
+
+### Fixes
+
+* Fix error handling middleware compatibility with Faraday v1.2.0 and above
+    | [askreet](https://github.com/askreet)
+    | [#30](https://github.com/bugsnag/bugsnag-api-ruby/pull/30)
+
+* Remove call to deprecated `URI.escape`
+    | [askreet](https://github.com/askreet)
+    | [#28](https://github.com/bugsnag/bugsnag-api-ruby/pull/28)
+
 ## 2.0.2 (21 Feb 2018)
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you're a member of the core team, follow these instructions for releasing bug
 ### Every time
 
 * Update `CHANGELOG.md`
-* Update the version number in `bugsnag-api.gemspec`
+* Update the version number in [`lib/bugsnag/api/version.rb`](./lib/bugsnag/api/version.rb)
 * Update `README.md` if necessary with changes to the interface or configuration
 * Commit/push your changes
 * Release to rubygems

--- a/lib/bugsnag/api/version.rb
+++ b/lib/bugsnag/api/version.rb
@@ -1,5 +1,5 @@
 module Bugsnag
   module Api
-    VERSION = "2.0.2"
+    VERSION = "2.0.3"
   end
 end


### PR DESCRIPTION
## 2.0.3 (11 May 2021)

### Fixes

* Fix error handling middleware compatibility with Faraday v1.2.0 and above
    | [askreet](https://github.com/askreet)
    | [#30](https://github.com/bugsnag/bugsnag-api-ruby/pull/30)

* Remove call to deprecated `URI.escape`
    | [askreet](https://github.com/askreet)
    | [#28](https://github.com/bugsnag/bugsnag-api-ruby/pull/28)
