### PR TITLE
Add stability and release endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
 inherit_from: .rubocop_todo.yml
 
+Metrics/ClassLength:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add stability and release endpoints
+    |  [#34](https://github.com/bugsnag/bugsnag-api-ruby/pull/34)
+
 ## 2.0.3 (11 May 2021)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This library borrows heavily from the code and philosophies of the fantastic [Oc
   - [Projects](#projects)
   - [Trends](#trends)
   - [Stability](#stability)
+  - [Releases](#releases)
 - [Advanced Configuration](#advanced-configuration)
 
 
@@ -380,6 +381,19 @@ Bugsnag::Api.trends_resolution("project-id", "2h")
 ```ruby
 # view a project's stability trend
 Bugsnag::Api.stability_trend("project-id")
+```
+
+### Releases
+
+```ruby
+# list the releases in a project
+Bugsnag::Api.releases("project-id")
+
+# view a single release
+Bugsnag::Api.release("project-id", "release-id")
+
+# list the releases in a release group
+Bugsnag::Api.releases_in_group("release-group-id")
 ```
 
 ## Advanced Configuration

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This library borrows heavily from the code and philosophies of the fantastic [Oc
   - [Pivots](#pivots)
   - [Projects](#projects)
   - [Trends](#trends)
+  - [Stability](#stability)
 - [Advanced Configuration](#advanced-configuration)
 
 
@@ -372,6 +373,13 @@ Bugsnag::Api.trends_buckets("project-id", 5, "error-id")
 
 # list a project's trends by resolution
 Bugsnag::Api.trends_resolution("project-id", "2h")
+```
+
+### Stability
+
+```ruby
+# view a project's stability trend
+Bugsnag::Api.stability_trend("project-id")
 ```
 
 ## Advanced Configuration

--- a/lib/bugsnag/api/client.rb
+++ b/lib/bugsnag/api/client.rb
@@ -10,6 +10,7 @@ require "bugsnag/api/client/events"
 require "bugsnag/api/client/pivots"
 require "bugsnag/api/client/trends"
 require "bugsnag/api/client/comments"
+require "bugsnag/api/client/stability"
 
 module Bugsnag
   module Api
@@ -28,6 +29,7 @@ module Bugsnag
       include Bugsnag::Api::Client::Pivots
       include Bugsnag::Api::Client::Trends
       include Bugsnag::Api::Client::Comments
+      include Bugsnag::Api::Client::Stability
 
       # Header keys that can be passed in options hash to {#get},{#head}
       CONVENIENCE_HEADERS = Set.new([:accept, :content_type])

--- a/lib/bugsnag/api/client.rb
+++ b/lib/bugsnag/api/client.rb
@@ -11,6 +11,7 @@ require "bugsnag/api/client/pivots"
 require "bugsnag/api/client/trends"
 require "bugsnag/api/client/comments"
 require "bugsnag/api/client/stability"
+require "bugsnag/api/client/releases"
 
 module Bugsnag
   module Api
@@ -30,6 +31,7 @@ module Bugsnag
       include Bugsnag::Api::Client::Trends
       include Bugsnag::Api::Client::Comments
       include Bugsnag::Api::Client::Stability
+      include Bugsnag::Api::Client::Releases
 
       # Header keys that can be passed in options hash to {#get},{#head}
       CONVENIENCE_HEADERS = Set.new([:accept, :content_type])

--- a/lib/bugsnag/api/client/releases.rb
+++ b/lib/bugsnag/api/client/releases.rb
@@ -1,0 +1,38 @@
+module Bugsnag
+  module Api
+    class Client
+      # Methods for the Releases API
+      module Releases
+        # List the Releases in a Project
+        #
+        # @option release_stage [String] Only Releases with this release stage will be returned
+        # @option base [String] Only Releases created before this time will be returned
+        # @option sort [String] How to sort the results, one of: timestamp, percent_of_sessions
+        # @option offset [Number] The pagination offset
+        # @option per_page [Number] The number of results to return per page
+        # @return [Array<Sawyer::Resource>] List of Events for the specified Error
+        # @see https://bugsnagapiv2.docs.apiary.io/#reference/projects/releases/list-releases-on-a-project
+        def releases(project_id, options = {})
+          get "projects/#{project_id}/releases", options
+        end
+
+        # View a single Release
+        #
+        # @see https://bugsnagapiv2.docs.apiary.io/#reference/projects/releases/view-a-release
+        def release(project_id, release_id, options = {})
+          get "projects/#{project_id}/releases/#{release_id}", options
+        end
+
+        # List the Releases in a Release Group
+        #
+        # @option per_page [Number] The number of results to return per page
+        # @option page_token [String] Value from the next relation in the Link response header to obtain the next page of results
+        # @return [Array<Sawyer::Resource>] List of Releases for the specified Release Group
+        # @see https://bugsnagapiv2.docs.apiary.io/#reference/projects/releases/list-releases-on-a-release-group
+        def releases_in_group(release_group_id, options = {})
+          get "release_groups/#{release_group_id}/releases", options
+        end
+      end
+    end
+  end
+end

--- a/lib/bugsnag/api/client/stability.rb
+++ b/lib/bugsnag/api/client/stability.rb
@@ -1,0 +1,16 @@
+module Bugsnag
+  module Api
+    class Client
+      # Methods for the Stability API
+      module Stability
+        # View the stability trend for a project
+        #
+        # @return [Sawyer::Resource] Stability trend
+        # @see https://bugsnagapiv2.docs.apiary.io/#reference/projects/stability-trend/view-the-stability-trend-for-a-project
+        def stability_trend(id, options = {})
+          get "projects/#{id}/stability_trend", options
+        end
+      end
+    end
+  end
+end

--- a/spec/bugsnag/api/client/releases_spec.rb
+++ b/spec/bugsnag/api/client/releases_spec.rb
@@ -1,0 +1,184 @@
+require "spec_helper"
+
+describe Bugsnag::Api::Client::Releases do
+  before do
+    @client = auth_token_client
+    @project_id = test_bugsnag_project_id
+    @release_id = test_bugsnag_release_id
+    @release_group_id = test_bugsnag_release_group_id
+
+    Bugsnag::Api.reset!
+  end
+
+  describe ".releases", :vcr do
+    it "gets as list of releases" do
+      releases = @client.releases(@project_id)
+
+      expect(releases).to be_an_instance_of(Array)
+
+      releases.map!(&:to_h)
+
+      expect(releases.first[:id]).to eq(@release_id)
+      expect(releases.first[:project_id]).to eq(@project_id)
+      expect(releases.first[:release_group_id]).to eq(@release_group_id)
+
+      expect(releases).to all have_key(:id)
+      expect(releases).to all have_key(:project_id)
+      expect(releases).to all have_key(:release_group_id)
+      expect(releases).to all have_key(:release_time)
+      expect(releases).to all have_key(:release_source)
+      expect(releases).to all have_key(:app_version)
+      expect(releases).to all have_key(:app_version_code)
+      expect(releases).to all have_key(:app_bundle_version)
+      expect(releases).to all have_key(:build_label)
+      expect(releases).to all have_key(:builder_name)
+      expect(releases).to all have_key(:build_tool)
+      expect(releases).to all have_key(:errors_introduced_count)
+      expect(releases).to all have_key(:errors_seen_count)
+      expect(releases).to all have_key(:sessions_count_in_last_24h)
+      expect(releases).to all have_key(:total_sessions_count)
+      expect(releases).to all have_key(:unhandled_sessions_count)
+      expect(releases).to all have_key(:accumulative_daily_users_seen)
+      expect(releases).to all have_key(:accumulative_daily_users_with_unhandled)
+      expect(releases).to all have_key(:metadata)
+      expect(releases).to all have_key(:release_stage)
+    end
+
+    it "accepts parameters" do
+      releases = @client.releases(
+        @project_id,
+        {
+          release_stage: 'development',
+          base: '2021-07-21T12:00:00Z',
+          sort: 'percent_of_sessions',
+          offset: 0,
+          per_page: 1
+        }
+      )
+
+      expect(releases).to be_an_instance_of(Array)
+
+      releases.map!(&:to_h)
+
+      expect(releases.first[:id]).to eq(@release_id)
+      expect(releases.first[:project_id]).to eq(@project_id)
+      expect(releases.first[:release_group_id]).to eq(@release_group_id)
+
+      expect(releases).to all have_key(:id)
+      expect(releases).to all have_key(:project_id)
+      expect(releases).to all have_key(:release_group_id)
+      expect(releases).to all have_key(:release_time)
+      expect(releases).to all have_key(:release_source)
+      expect(releases).to all have_key(:app_version)
+      expect(releases).to all have_key(:app_version_code)
+      expect(releases).to all have_key(:app_bundle_version)
+      expect(releases).to all have_key(:build_label)
+      expect(releases).to all have_key(:builder_name)
+      expect(releases).to all have_key(:build_tool)
+      expect(releases).to all have_key(:errors_introduced_count)
+      expect(releases).to all have_key(:errors_seen_count)
+      expect(releases).to all have_key(:sessions_count_in_last_24h)
+      expect(releases).to all have_key(:total_sessions_count)
+      expect(releases).to all have_key(:unhandled_sessions_count)
+      expect(releases).to all have_key(:accumulative_daily_users_seen)
+      expect(releases).to all have_key(:accumulative_daily_users_with_unhandled)
+      expect(releases).to all have_key(:metadata)
+      expect(releases).to all have_key(:release_stage)
+    end
+  end
+
+  describe ".release", :vcr do
+    it "gets a single release" do
+      release = @client.release(@project_id, @release_id)
+
+      expect(release.id).to eq(@release_id)
+      expect(release.project_id).to eq(@project_id)
+      expect(release.release_group_id).to eq(@release_group_id)
+      expect(release.release_time).not_to be_nil
+      expect(release.release_source).not_to be_nil
+      expect(release.app_version).not_to be_nil
+      expect(release.app_version_code).not_to be_nil
+      expect(release.app_bundle_version).not_to be_nil
+      expect(release.build_label).not_to be_nil
+      expect(release.builder_name).not_to be_nil
+      expect(release.build_tool).not_to be_nil
+      expect(release.errors_introduced_count).not_to be_nil
+      expect(release.errors_seen_count).not_to be_nil
+      expect(release.sessions_count_in_last_24h).not_to be_nil
+      expect(release.total_sessions_count).not_to be_nil
+      expect(release.unhandled_sessions_count).not_to be_nil
+      expect(release.accumulative_daily_users_seen).not_to be_nil
+      expect(release.accumulative_daily_users_with_unhandled).not_to be_nil
+      expect(release.metadata).not_to be_nil
+      expect(release.release_stage).not_to be_nil
+    end
+  end
+
+  describe ".release_groups", :vcr do
+    it "gets releases in a release group" do
+      releases = @client.releases_in_group(@release_group_id)
+
+      expect(releases).to be_an_instance_of(Array)
+
+      releases.map!(&:to_h)
+
+      expect(releases.first[:id]).to eq(@release_id)
+      expect(releases.first[:project_id]).to eq(@project_id)
+      expect(releases.first[:release_group_id]).to eq(@release_group_id)
+
+      expect(releases).to all have_key(:id)
+      expect(releases).to all have_key(:project_id)
+      expect(releases).to all have_key(:release_group_id)
+      expect(releases).to all have_key(:release_time)
+      expect(releases).to all have_key(:release_source)
+      expect(releases).to all have_key(:app_version)
+      expect(releases).to all have_key(:app_version_code)
+      expect(releases).to all have_key(:app_bundle_version)
+      expect(releases).to all have_key(:build_label)
+      expect(releases).to all have_key(:builder_name)
+      expect(releases).to all have_key(:build_tool)
+      expect(releases).to all have_key(:errors_introduced_count)
+      expect(releases).to all have_key(:errors_seen_count)
+      expect(releases).to all have_key(:sessions_count_in_last_24h)
+      expect(releases).to all have_key(:total_sessions_count)
+      expect(releases).to all have_key(:unhandled_sessions_count)
+      expect(releases).to all have_key(:accumulative_daily_users_seen)
+      expect(releases).to all have_key(:accumulative_daily_users_with_unhandled)
+      expect(releases).to all have_key(:metadata)
+      expect(releases).to all have_key(:release_stage)
+    end
+
+    it "accepts parameters" do
+      releases = @client.releases_in_group(@release_group_id, { per_page: 1 })
+
+      expect(releases).to be_an_instance_of(Array)
+
+      releases.map!(&:to_h)
+
+      expect(releases.first[:id]).to eq(@release_id)
+      expect(releases.first[:project_id]).to eq(@project_id)
+      expect(releases.first[:release_group_id]).to eq(@release_group_id)
+
+      expect(releases).to all have_key(:id)
+      expect(releases).to all have_key(:project_id)
+      expect(releases).to all have_key(:release_group_id)
+      expect(releases).to all have_key(:release_time)
+      expect(releases).to all have_key(:release_source)
+      expect(releases).to all have_key(:app_version)
+      expect(releases).to all have_key(:app_version_code)
+      expect(releases).to all have_key(:app_bundle_version)
+      expect(releases).to all have_key(:build_label)
+      expect(releases).to all have_key(:builder_name)
+      expect(releases).to all have_key(:build_tool)
+      expect(releases).to all have_key(:errors_introduced_count)
+      expect(releases).to all have_key(:errors_seen_count)
+      expect(releases).to all have_key(:sessions_count_in_last_24h)
+      expect(releases).to all have_key(:total_sessions_count)
+      expect(releases).to all have_key(:unhandled_sessions_count)
+      expect(releases).to all have_key(:accumulative_daily_users_seen)
+      expect(releases).to all have_key(:accumulative_daily_users_with_unhandled)
+      expect(releases).to all have_key(:metadata)
+      expect(releases).to all have_key(:release_stage)
+    end
+  end
+end

--- a/spec/bugsnag/api/client/stability_spec.rb
+++ b/spec/bugsnag/api/client/stability_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe Bugsnag::Api::Client::Stability do
+  before do
+    @client = auth_token_client
+    @project_id = test_bugsnag_project_id
+
+    Bugsnag::Api.reset!
+  end
+
+  describe ".stability_trend", :vcr do
+    it "gets the stability trend" do
+      stability_trend = @client.stability_trend(@project_id)
+
+      expect(stability_trend.project_id).to eq(@project_id)
+      expect(stability_trend.release_stage_name).not_to be_nil
+      expect(stability_trend.timeline_points).to be_an_instance_of(Array)
+
+      # convert each "Sawyer::Resource" to a hash so we can use the "have_key" matcher
+      timeline_points = stability_trend.timeline_points.map(&:to_h)
+
+      expect(timeline_points).to all have_key(:bucket_start)
+      expect(timeline_points).to all have_key(:bucket_end)
+      expect(timeline_points).to all have_key(:total_sessions_count)
+      expect(timeline_points).to all have_key(:unhandled_sessions_count)
+      expect(timeline_points).to all have_key(:users_seen)
+      expect(timeline_points).to all have_key(:users_with_unhandled)
+
+      assert_requested(:get, bugsnag_url("/projects/#{@project_id}/stability_trend"))
+    end
+  end
+end

--- a/spec/cassettes/Bugsnag_Api_Client_Releases/_release/gets_a_single_release.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Releases/_release/gets_a_single_release.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/releases/BUGSNAG_RELEASE_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 21 Jul 2021 11:03:45 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      Etag:
+      - W/"9de5aed70023ff924dce3a5b17003ae5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bbaad3d3-c3f4-4f9b-b8d5-9878502e2540
+      X-Runtime:
+      - '0.510790'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"BUGSNAG_RELEASE_ID","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"BUGSNAG_RELEASE_GROUP_ID","release_time":"2021-07-08T14:26:55+00:00","release_source":"event","app_version":"1.2.3","app_version_code":"","app_bundle_version":"","build_label":"1.2.3","builder_name":"","build_tool":"","errors_introduced_count":1,"errors_seen_count":1,"sessions_count_in_last_24h":0,"total_sessions_count":0,"unhandled_sessions_count":0,"accumulative_daily_users_seen":0,"accumulative_daily_users_with_unhandled":0,"metadata":{},"release_stage":{"name":"production"}}'
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 11:03:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Bugsnag_Api_Client_Releases/_release_groups/accepts_parameters.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Releases/_release_groups/accepts_parameters.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/release_groups/BUGSNAG_RELEASE_GROUP_ID/releases?per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 21 Jul 2021 11:27:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      Link:
+      - <https://api.bugsnag.com/release_groups/BUGSNAG_RELEASE_GROUP_ID/releases?page_token=BUGSNAG_RELEASE_ID%7C1625754415284%7C0&per_page=1>;
+        rel="next"
+      Etag:
+      - W/"5d40708836e0a05e40d26b81e9192067"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a3fc8c81-6f56-4039-a64b-37f50d827061
+      X-Runtime:
+      - '0.549084'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"BUGSNAG_RELEASE_ID","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"BUGSNAG_RELEASE_GROUP_ID","release_time":"2021-07-08T14:26:55+00:00","release_source":"event","app_version":"1.2.3","app_version_code":"","app_bundle_version":"","build_label":"1.2.3","builder_name":"","build_tool":"","errors_introduced_count":1,"errors_seen_count":1,"sessions_count_in_last_24h":0,"total_sessions_count":0,"unhandled_sessions_count":0,"accumulative_daily_users_seen":0,"accumulative_daily_users_with_unhandled":0,"metadata":{},"release_stage":{"name":"production"}}]'
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 11:27:22 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Bugsnag_Api_Client_Releases/_release_groups/gets_releases_in_a_release_group.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Releases/_release_groups/gets_releases_in_a_release_group.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/release_groups/BUGSNAG_RELEASE_GROUP_ID/releases
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 21 Jul 2021 11:07:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      Etag:
+      - W/"5d40708836e0a05e40d26b81e9192067"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c7048146-ff4b-42d3-b6ca-f115151d1f90
+      X-Runtime:
+      - '0.804233'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"BUGSNAG_RELEASE_ID","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"BUGSNAG_RELEASE_GROUP_ID","release_time":"2021-07-08T14:26:55+00:00","release_source":"event","app_version":"1.2.3","app_version_code":"","app_bundle_version":"","build_label":"1.2.3","builder_name":"","build_tool":"","errors_introduced_count":1,"errors_seen_count":1,"sessions_count_in_last_24h":0,"total_sessions_count":0,"unhandled_sessions_count":0,"accumulative_daily_users_seen":0,"accumulative_daily_users_with_unhandled":0,"metadata":{},"release_stage":{"name":"production"}}]'
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 11:07:53 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Bugsnag_Api_Client_Releases/_releases/accepts_parameters.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Releases/_releases/accepts_parameters.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/releases?base=2021-07-21T12:00:00Z&offset=0&per_page=1&release_stage=development&sort=percent_of_sessions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 21 Jul 2021 10:22:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Total-Count:
+      - '6'
+      Link:
+      - <https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/releases?base=2021-07-21T12%3A00%3A00Z&offset=1&per_page=1&release_stage=development&sort=percent_of_sessions>;
+        rel="next"
+      Etag:
+      - W/"4219c5fa74334a52d3a02a1deafb2524"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7c8cb266-3c07-4825-95c2-3b0a5cb1d432
+      X-Runtime:
+      - '0.682393'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"BUGSNAG_RELEASE_ID","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"BUGSNAG_RELEASE_GROUP_ID","release_time":"2021-05-17T09:25:52+00:00","release_source":"session","app_version":"12.0.6","app_version_code":"","app_bundle_version":"","build_label":"12.0.6","builder_name":"","build_tool":"","errors_introduced_count":2,"errors_seen_count":2,"sessions_count_in_last_24h":0,"total_sessions_count":1,"unhandled_sessions_count":1,"accumulative_daily_users_seen":1,"accumulative_daily_users_with_unhandled":1,"metadata":{},"release_stage":{"name":"development"}}]'
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 10:22:43 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Bugsnag_Api_Client_Releases/_releases/gets_as_list_of_releases.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Releases/_releases/gets_as_list_of_releases.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/releases
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 21 Jul 2021 10:16:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '29'
+      X-Total-Count:
+      - '18'
+      Link:
+      - <https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/releases?offset=5>; rel="next"
+      Etag:
+      - W/"ed1f3093157525e1d0e3de94b66fb361"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6106538c-08af-46f6-8750-22cb613f89c5
+      X-Runtime:
+      - '0.585272'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"BUGSNAG_RELEASE_ID","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"BUGSNAG_RELEASE_GROUP_ID","release_time":"2021-07-08T14:26:55+00:00","release_source":"event","app_version":"1.2.3","app_version_code":"","app_bundle_version":"","build_label":"1.2.3","builder_name":"","build_tool":"","errors_introduced_count":1,"errors_seen_count":1,"sessions_count_in_last_24h":0,"total_sessions_count":0,"unhandled_sessions_count":0,"accumulative_daily_users_seen":0,"accumulative_daily_users_with_unhandled":0,"metadata":{},"release_stage":{"name":"production"}},{"id":"60a236a0c024ebcf749e8611","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"60a236a0373c863538dc968a","release_time":"2021-05-17T09:25:52+00:00","release_source":"session","app_version":"12.0.6","app_version_code":"","app_bundle_version":"","build_label":"12.0.6","builder_name":"","build_tool":"","errors_introduced_count":2,"errors_seen_count":2,"sessions_count_in_last_24h":0,"total_sessions_count":1,"unhandled_sessions_count":1,"accumulative_daily_users_seen":1,"accumulative_daily_users_with_unhandled":1,"metadata":{},"release_stage":{"name":"development"}},{"id":"60a2356cc024ebcf7495230a","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"6092ad2dc57ea33c2c797029","release_time":"2021-05-17T09:20:44+00:00","release_source":"session","app_version":"2.0.0","app_version_code":"","app_bundle_version":"","build_label":"2.0.0","builder_name":"","build_tool":"","errors_introduced_count":3,"errors_seen_count":8,"sessions_count_in_last_24h":0,"total_sessions_count":3,"unhandled_sessions_count":2,"accumulative_daily_users_seen":1,"accumulative_daily_users_with_unhandled":1,"metadata":{},"release_stage":{"name":"production"}},{"id":"60953ed4470751c2620dac65","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"6092b4edc57ea33c2c79707d","release_time":"2021-05-07T13:21:24+00:00","release_source":"session","app_version":"1.0.0","app_version_code":"","app_bundle_version":"","build_label":"1.0.0","builder_name":"","build_tool":"","errors_introduced_count":8,"errors_seen_count":25,"sessions_count_in_last_24h":0,"total_sessions_count":29,"unhandled_sessions_count":11,"accumulative_daily_users_seen":4,"accumulative_daily_users_with_unhandled":4,"metadata":{},"release_stage":{"name":"production"}},{"id":"60953c5c470751c262f347f1","project_id":"BUGSNAG_PROJECT_ID","release_group_id":"60953c5cc57ea33c2c7980f7","release_time":"2021-05-07T13:10:52+00:00","release_source":"session","app_version":"1.0.0-bbbb","app_version_code":"","app_bundle_version":"","build_label":"1.0.0-bbbb","builder_name":"","build_tool":"","errors_introduced_count":7,"errors_seen_count":11,"sessions_count_in_last_24h":0,"total_sessions_count":17,"unhandled_sessions_count":7,"accumulative_daily_users_seen":3,"accumulative_daily_users_with_unhandled":3,"metadata":{},"release_stage":{"name":"production"}}]'
+    http_version: 
+  recorded_at: Wed, 21 Jul 2021 10:16:11 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/Bugsnag_Api_Client_Stability/_stability_trend/gets_the_stability_trend.yml
+++ b/spec/cassettes/Bugsnag_Api_Client_Stability/_stability_trend/gets_the_stability_trend.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bugsnag.com/projects/BUGSNAG_PROJECT_ID/stability_trend
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Bugsnag API Ruby Gem 2.0.3
+      Content-Type:
+      - application/json
+      X-Version:
+      - '2'
+      X-Bugsnag-Api:
+      - 'true'
+      Authorization:
+      - token BUGSNAG_AUTH_TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 20 Jul 2021 15:18:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ratelimit-Limit:
+      - '30'
+      X-Ratelimit-Remaining:
+      - '28'
+      Etag:
+      - W/"e187a5d89e7c6769b1733ac6f27b40c2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 29002730-cc73-43bf-8e19-00d56b1fa14c
+      X-Runtime:
+      - '0.076007'
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Security-Policy:
+      - 'default-src ''self''; child-src https://*.stripe.com headway-widget.net https://*.youtube.com
+        https://www.google.com https://www.recaptcha.net; connect-src ''self'' https://api.bugsnag.com
+        https://notify.bugsnag.com https://sessions.bugsnag.com https://*.stripe.com
+        https://bugsnag.zendesk.com https://ekr.zdassets.com https://api.lever.co;
+        font-src ''self'' https://maxcdn.bootstrapcdn.com https://d2wy8f7a9ursnm.cloudfront.net;
+        img-src ''self'' data: https://notify.bugsnag.com https://*.stripe.com https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net https://px.ads.linkedin.com; object-src
+        ''self''; script-src ''self'' https://d2wy8f7a9ursnm.cloudfront.net https://*.stripe.com
+        https://maxcdn.bootstrapcdn.com https://code.jquery.com https://static.zdassets.com
+        https://ekr.zdassets.com https://cdn.headwayapp.co https://www.recaptcha.net
+        https://www.gstatic.com; style-src ''self'' ''unsafe-inline'' https://maxcdn.bootstrapcdn.com
+        https://d2wy8f7a9ursnm.cloudfront.net'
+      X-Robots-Tag:
+      - noindex, nofollow
+      Strict-Transport-Security:
+      - max-age=31536000
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"project_id":"BUGSNAG_PROJECT_ID","release_stage_name":"development","timeline_points":[{"bucket_start":"2021-06-21T00:00:00.000Z","bucket_end":"2021-06-22T00:00:00.000Z","total_sessions_count":25,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-22T00:00:00.000Z","bucket_end":"2021-06-23T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-23T00:00:00.000Z","bucket_end":"2021-06-24T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-24T00:00:00.000Z","bucket_end":"2021-06-25T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-25T00:00:00.000Z","bucket_end":"2021-06-26T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-26T00:00:00.000Z","bucket_end":"2021-06-27T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-27T00:00:00.000Z","bucket_end":"2021-06-28T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-28T00:00:00.000Z","bucket_end":"2021-06-29T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-29T00:00:00.000Z","bucket_end":"2021-06-30T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-06-30T00:00:00.000Z","bucket_end":"2021-07-01T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-01T00:00:00.000Z","bucket_end":"2021-07-02T00:00:00.000Z","total_sessions_count":5,"unhandled_sessions_count":3,"unhandled_rate":0.6,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-02T00:00:00.000Z","bucket_end":"2021-07-03T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-03T00:00:00.000Z","bucket_end":"2021-07-04T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-04T00:00:00.000Z","bucket_end":"2021-07-05T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-05T00:00:00.000Z","bucket_end":"2021-07-06T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-06T00:00:00.000Z","bucket_end":"2021-07-07T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-07T00:00:00.000Z","bucket_end":"2021-07-08T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-08T00:00:00.000Z","bucket_end":"2021-07-09T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-09T00:00:00.000Z","bucket_end":"2021-07-10T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-10T00:00:00.000Z","bucket_end":"2021-07-11T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-11T00:00:00.000Z","bucket_end":"2021-07-12T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-12T00:00:00.000Z","bucket_end":"2021-07-13T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-13T00:00:00.000Z","bucket_end":"2021-07-14T00:00:00.000Z","total_sessions_count":4,"unhandled_sessions_count":2,"unhandled_rate":0.5,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-14T00:00:00.000Z","bucket_end":"2021-07-15T00:00:00.000Z","total_sessions_count":26,"unhandled_sessions_count":2,"unhandled_rate":0.07692307692307693,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-15T00:00:00.000Z","bucket_end":"2021-07-16T00:00:00.000Z","total_sessions_count":149,"unhandled_sessions_count":3,"unhandled_rate":0.020134228187919462,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-16T00:00:00.000Z","bucket_end":"2021-07-17T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-17T00:00:00.000Z","bucket_end":"2021-07-18T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-18T00:00:00.000Z","bucket_end":"2021-07-19T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-19T00:00:00.000Z","bucket_end":"2021-07-20T00:00:00.000Z","total_sessions_count":0,"unhandled_sessions_count":0,"unhandled_rate":0.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0},{"bucket_start":"2021-07-20T00:00:00.000Z","bucket_end":"2021-07-21T00:00:00.000Z","total_sessions_count":16,"unhandled_sessions_count":20,"unhandled_rate":1.0,"users_seen":0,"users_with_unhandled":0,"unhandled_user_rate":0.0}]}'
+    http_version: 
+  recorded_at: Tue, 20 Jul 2021 15:18:48 GMT
+recorded_with: VCR 2.9.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,8 @@ VCR.configure do |c|
   c.filter_sensitive_data("BUGSNAG_COLLABORATOR_EMAIL") { test_bugsnag_collaborator }
   c.filter_sensitive_data("BUGSNAG_ERROR_ID") { test_bugsnag_error_id }
   c.filter_sensitive_data("BUGSNAG_EVENT_ID") { test_bugsnag_event_id }
-  
+  c.filter_sensitive_data("BUGSNAG_RELEASE_ID") { test_bugsnag_release_id }
+  c.filter_sensitive_data("BUGSNAG_RELEASE_GROUP_ID") { test_bugsnag_release_group_id }
 end
 
 def auth_token_client
@@ -121,4 +122,12 @@ end
 
 def test_bugsnag_collaborator
   ENV["BUGSNAG_TEST_COLLABORATOR_EMAIL"] || "BUGSNAG_COLLABORATOR_EMAIL"
+end
+
+def test_bugsnag_release_id
+  ENV["BUGSNAG_TEST_RELEASE_ID"] || "BUGSNAG_RELEASE_ID"
+end
+
+def test_bugsnag_release_group_id
+  ENV["BUGSNAG_TEST_RELEASE_GROUP_ID"] || "BUGSNAG_RELEASE_GROUP_ID"
 end


### PR DESCRIPTION
## Goal

Adds endpoints for stability and releases

### Stability

```ruby
# view a project's stability trend
Bugsnag::Api.stability_trend("project-id")
```

### Releases

```ruby
# list the releases in a project
Bugsnag::Api.releases("project-id")

# view a single release
Bugsnag::Api.release("project-id", "release-id")

# list the releases in a release group
Bugsnag::Api.releases_in_group("release-group-id")
```