### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 2.1.0 (28 July 2021)
 
 ### Enhancements
 

--- a/lib/bugsnag/api/version.rb
+++ b/lib/bugsnag/api/version.rb
@@ -1,5 +1,5 @@
 module Bugsnag
   module Api
-    VERSION = "2.0.3"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
## 2.1.0 (28 July 2021)

### Enhancements

* Add stability and release endpoints
    |  [#34](https://github.com/bugsnag/bugsnag-api-ruby/pull/34)