### PR TITLE
Fix Faraday deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+* Fix Faraday deprecation warning
+    | [sambostock](https://github.com/sambostock)
+    | [#36](https://github.com/bugsnag/bugsnag-api-ruby/pull/36)
+
 ## 2.1.0 (28 July 2021)
 
 ### Enhancements

--- a/lib/bugsnag/api/client.rb
+++ b/lib/bugsnag/api/client.rb
@@ -13,6 +13,8 @@ require "bugsnag/api/client/comments"
 require "bugsnag/api/client/stability"
 require "bugsnag/api/client/releases"
 
+require "base64"
+
 module Bugsnag
   module Api
 
@@ -169,9 +171,11 @@ module Bugsnag
           http.headers[:user_agent] = configuration.user_agent
 
           if basic_authenticated?
-            http.basic_auth configuration.email, configuration.password
+            credentials = Base64.strict_encode64("#{configuration.email}:#{configuration.password}")
+
+            http.headers[:Authorization] = "Basic #{credentials}"
           elsif token_authenticated?
-            http.authorization "token", configuration.auth_token
+            http.headers[:Authorization] = "token #{configuration.auth_token}"
           end
         end
       end


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

This addresses the following deprecation warning:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

## Design

<!-- Why was this approach used? -->

We more-or-less use the approach suggested by the deprecation message and documentation.

However, Faraday 2.x will support passing a `Basic` auth username and password to the middleware, and encoding it automatically, but versions prior to that do not. Therefore, we encode it ourselves for backwards compatibility.

This is the same approach I suggested in https://github.com/octokit/octokit.rb/pull/1359#issuecomment-916389545.

## Changeset

<!-- What changed? -->

The method for specifying the `Authorization` header has been updated.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->

Presumably the existing tests should cover it?