### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 Changelog
 =========
 
-## TBD
+## 2.1.1 (2 November 2021)
+
+### Fixes
 
 * Fix Faraday deprecation warning
     | [sambostock](https://github.com/sambostock)

--- a/lib/bugsnag/api/version.rb
+++ b/lib/bugsnag/api/version.rb
@@ -1,5 +1,5 @@
 module Bugsnag
   module Api
-    VERSION = "2.1.0"
+    VERSION = "2.1.1"
   end
 end


### PR DESCRIPTION
## 2.1.1 (2 November 2021)

### Fixes

* Fix Faraday deprecation warning
    | [sambostock](https://github.com/sambostock)
    | [#36](https://github.com/bugsnag/bugsnag-api-ruby/pull/36)