### PR TITLE
Upgrade dependency: sawyer

### DIFF
--- a/bugsnag-api.gemspec
+++ b/bugsnag-api.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     # crack is used by webmock
     spec.add_development_dependency "crack", "< 0.4.5"
   else
-    spec.add_dependency "sawyer", '~> 0.8.1'
+    spec.add_dependency "sawyer", '~> 0.9.2'
 
     spec.add_development_dependency "rake"
     spec.add_development_dependency "rubocop", "~> 0.52.1"

--- a/lib/bugsnag/api/response/raise_error.rb
+++ b/lib/bugsnag/api/response/raise_error.rb
@@ -8,7 +8,7 @@ module Bugsnag
 
       # This class raises an Bugsnag-flavored exception based
       # HTTP status codes returned by the API
-      class RaiseError < Faraday::Response::Middleware
+      class RaiseError < Faraday::Response::RaiseError
         def on_complete(response)
           if error = Bugsnag::Api::Error.from_response(response)
             raise error


### PR DESCRIPTION
## Goal

`sawyer` dependency is really outdated and uses really old `faraday`. Goal is to use up-to-date dependencies.

## Changeset

1. Upgraded sawyer to latest.
2. RaiseError is now subclass of `Faraday::Response::RaiseError`. The API seems the same, so I think it's a drop-in replacement.

## Testing

I just ran `rspec` on changes:
```
88 examples, 0 failures, 9 pending

% ruby --version
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
```