### PR TITLE
Require Ruby 2.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
     | [ilvez](https://github.com/ilvez)
     | [#43](https://github.com/bugsnag/bugsnag-api-ruby/pull/43)
 
+* Require Ruby 2.6+
+    | [#44](https://github.com/bugsnag/bugsnag-api-ruby/pull/44)
+
 ## 2.1.1 (2 November 2021)
 
 ### Fixes

--- a/bugsnag-api.gemspec
+++ b/bugsnag-api.gemspec
@@ -18,55 +18,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  if RUBY_VERSION < "2.2.0"
-    spec.add_dependency "sawyer", '0.8.1'
+  spec.required_ruby_version = ">= 2.6"
 
-    spec.add_development_dependency "rake", "< 12.0.0"
-    spec.add_development_dependency "rubocop", "0.41.2"
-    spec.add_development_dependency "faker", "1.3.0"
+  spec.add_dependency "sawyer", '~> 0.9.2'
 
-    # i18n is used by faker
-    spec.add_development_dependency "i18n", "< 1.0.0"
-
-    # crack is used by webmock
-    spec.add_development_dependency "crack", "< 0.4.5"
-  else
-    spec.add_dependency "sawyer", '~> 0.9.2'
-
-    spec.add_development_dependency "rake"
-    spec.add_development_dependency "rubocop", "~> 0.52.1"
-    spec.add_development_dependency "faker", "> 1.7.3"
-  end
-
-  if RUBY_VERSION < "2.0.0"
-    spec.add_development_dependency "webmock", "2.3.2"
-    spec.add_development_dependency "addressable", "2.3.6"
-
-    # hashdiff is used by webmock
-    spec.add_development_dependency "hashdiff", "< 0.3.8"
-
-    # parser is used by rubocop
-    spec.add_development_dependency "parser", "< 2.5.0"
-  else
-    spec.add_development_dependency "webmock", "> 2.3.2"
-    spec.add_development_dependency "addressable", "> 2.3.6"
-  end
-
-  if RUBY_VERSION < "2.0.0"
-    spec.add_development_dependency "json", "< 2.0.0"
-  elsif RUBY_VERSION < "2.3.0"
-    spec.add_development_dependency "json", "< 2.6.0"
-  else
-    spec.add_development_dependency "json"
-  end
-
-  # public_suffix is used by addressable & sawyer
-  if RUBY_VERSION < "2.0.0"
-    spec.add_development_dependency "public_suffix", "< 1.5.0"
-  elsif RUBY_VERSION < "2.1.0"
-    spec.add_development_dependency "public_suffix", "< 3.0.0"
-  end
-
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rubocop", "~> 0.52.1"
+  spec.add_development_dependency "faker", "> 1.7.3"
+  spec.add_development_dependency "webmock", "> 2.3.2"
+  spec.add_development_dependency "addressable", "> 2.3.6"
+  spec.add_development_dependency "json"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", "~> 2.9"
 end


### PR DESCRIPTION
## Goal

Require Ruby 2.6+ to use this Gem. This simplifies our dependency tree massively and should make future changes much safer to implement

This will be released as a new major version — v3.0.0