### PR TITLE
Fix example code accessing a project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ account.rels[:upgrade].href
 Resources returned by Bugsnag API methods contain not only data but hypermedia link relations:
 
 ```ruby
-project = Bugsnag::Api.projects("organization-id")
+project = Bugsnag::Api.projects("organization-id").first
 
 # Get the users rel, returned from the API as users_url in the resource
 project.rels[:errors].href


### PR DESCRIPTION
## Goal

Avoid running into
```
NoMethodError: undefined method `rels' for an instance of Array
```
when executing 
```ruby
project.rels[:errors].href
```
after initializing `project` with 
```ruby
project = Bugsnag::Api.projects("organization-id")
```

## Design

/

## Changeset

/

## Testing

/