### PR TITLE
Fix issue with updating multiple errors at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 3.0.1 (14 January 2025)
+
+### Fixes
+
+* Fix issue with update several errors at once
+    | [#52](https://github.com/bugsnag/bugsnag-api-ruby/pull/52)
+
 ## 3.0.0 (3 November 2022)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 Changelog
 =========
 
-## 3.0.1 (14 January 2025)
+## 3.0.1 (27 January 2025)
 
 ### Fixes
 
-* Fix issue with update several errors at once
+* Fix issue with updating several errors at once
     | [#52](https://github.com/bugsnag/bugsnag-api-ruby/pull/52)
 
 ## 3.0.0 (3 November 2022)

--- a/lib/bugsnag/api/client/errors.rb
+++ b/lib/bugsnag/api/client/errors.rb
@@ -42,7 +42,7 @@ module Bugsnag
           when String
             patch "projects/#{project_id}/errors/#{ids}", options.merge({:operation => operation})
           when Array
-            defaults = {:operation => operation, :query => {:error_ids => ids.join(' ')}}
+            defaults = {:operation => operation, :query => {:error_ids => ids}}
             merged_opts = deep_merge(defaults, options)
             patch "projects/#{project_id}/errors", merged_opts
           else

--- a/lib/bugsnag/api/version.rb
+++ b/lib/bugsnag/api/version.rb
@@ -1,5 +1,5 @@
 module Bugsnag
   module Api
-    VERSION = "3.0.0"
+    VERSION = "3.0.1"
   end
 end

--- a/spec/bugsnag/api/client/errors_spec.rb
+++ b/spec/bugsnag/api/client/errors_spec.rb
@@ -42,11 +42,11 @@ describe Bugsnag::Api::Client::Errors do
     end
     
     it "updates and returns the updated errors" do
-      errors = @client.update_errors @project_id, [@error_id], "fix", {:severity => "warn"}
+      errors = @client.update_errors @project_id, [@error_id, @error_id], "fix", {:severity => "warn"}
       expect(errors.operation).to_not be_nil
       expect(errors[@error_id].status).to eq("fixed")
 
-      assert_requested :patch, bugsnag_url("/projects/#{@project_id}/errors?error_ids=#{@error_id}")
+      assert_requested :patch, bugsnag_url("/projects/#{@project_id}/errors?error_ids[]=#{@error_id}&error_ids[]=#{@error_id}")
     end
   end
 


### PR DESCRIPTION
## Goal

The errors don't need to be joined before being delivered, the library handles that for us.

Fixes #51.